### PR TITLE
Upgrade cert-manager objects

### DIFF
--- a/argo-workflows/resources/argo-workflows-certificate.yaml
+++ b/argo-workflows/resources/argo-workflows-certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: argo-workflows-cert

--- a/argo-workflows/resources/argo-workflows-issuer.yaml
+++ b/argo-workflows/resources/argo-workflows-issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: argo-workflows-issuer

--- a/dex/dex-certificate.yaml
+++ b/dex/dex-certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: dex-cert

--- a/dex/dex-issuer.yaml
+++ b/dex/dex-issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: dex-issuer

--- a/prometheus-operator/resources/grafana-certificate.yaml
+++ b/prometheus-operator/resources/grafana-certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: grafana-cert

--- a/prometheus-operator/resources/grafana-issuer.yaml
+++ b/prometheus-operator/resources/grafana-issuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: grafana-issuer


### PR DESCRIPTION
https://cert-manager.io/docs/installation/upgrading/remove-deprecated-apis/

> Sync
> Failed
> one or more synchronization tasks are not valid (retried 5 times).

> The Kubernetes API could not find version "v1alpha2" of cert-manager.io/Certificate for requested resource argo/argo-workflows-cert. Version "v1" of cert-manager.io/Certificate is installed on the destination cluster.

https://cd.apps.argoproj.io/applications/argocd/argo-workflows?operation=true&resource=
