### PR TITLE
feat: add webhook ingress example

### DIFF
--- a/argocd/base/argo-cd-webhook-ingress.yaml
+++ b/argocd/base/argo-cd-webhook-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: argo-cd-webhook
+spec:
+  rules:
+    - host: cd.apps.argoproj.io
+      http:
+        paths:
+          - path: /api/webhook
+            pathType: Prefix
+            backend:
+              service:
+                name: argocd-applicationset-controller
+                port:
+                  number: 7000
+  tls:
+    - hosts:
+        - cd.apps.argoproj.io
+      secretName: argocd-secret


### PR DESCRIPTION
The need for the ingress webhook is poorly documented. It's visible in the helm chart values.yaml, but near impossible to discover this on you own reading documentation.

Related to https://github.com/argoproj/argo-cd/pull/21543