### PR TITLE
fix(grafana): Clean up ArgoCD dashboard for demo instance

### DIFF
--- a/prometheus-operator/dashboard.json
+++ b/prometheus-operator/dashboard.json
@@ -18,7 +18,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1555,
+  "id": null,
+  "liveNow": false,
   "links": [],
   "panels": [
     {
@@ -2360,7 +2361,7 @@
     }
   ],
   "preload": false,
-  "refresh": "",
+  "refresh": "30s",
   "schemaVersion": 41,
   "tags": [],
   "templating": {
@@ -2595,5 +2596,5 @@
   "timezone": "",
   "title": "ArgoCD",
   "uid": "LCAgc9rWz",
-  "version": 7092
+  "version": 1
 }


### PR DESCRIPTION
## Problem

The demo Grafana instance lost its ArgoCD dashboard during the cloud migration from Intuit GCP to CNCF cloud. The dashboard.json file had stale artifacts from the previous Grafana instance that prevented clean import.

## Root Cause

The dashboard.json had instance-specific metadata that breaks when imported into a new Grafana instance:
- `id: 1555` — old instance internal ID
- `version: 7092` — inflated from repeated saves on the old instance
- Missing `liveNow` field
- `refresh` was set to empty string

## Fix

Cleaned up the dashboard.json to make it a portable, importable Grafana dashboard:
- Reset `id` to `null`
- Reset `version` to `1`
- Added `liveNow: false`
- Fixed `refresh` to `30s`

The `kustomization.yaml` already has the correct `configMapGenerator` setup with the `grafana_dashboard: '1'` label for auto-discovery. With these changes, the dashboard will be properly imported into the demo Grafana instance.

## Testing

- Validated the JSON is valid Grafana dashboard format
- Verified the dashboard has the correct schemaVersion (41) for Grafana 11
- Confirmed the kustomization.yaml configMapGenerator is correctly configured

## Related Issues

- Fixes argoproj/argo-cd#17922

## DCO

Signed-off-by: Lohit Kolluri <lohitkolluri@gmail.com>